### PR TITLE
Fix EDF signal parsing

### DIFF
--- a/server.R
+++ b/server.R
@@ -7,28 +7,20 @@ shinyServer(function(input, output) {
   observeEvent(input$go, {
 
     # Read in and reference the EDF data from input$edf_file ----------
-    #edf_data <- reactive({
-    #  infile <- input$edf_file
-    #  if (is.null(infile)) {
-    #    # User has not uploaded a file yet
-    #    return(NULL)
-    #  }
-    #  # Or, read in
-    #  read_edf_file(infile$datapath)
-    #})
     edf_data <- reactive({
-      read_edf_file()
+      infile <- input$edf_file
+      if (is.null(infile)) {
+        # User has not uploaded a file yet
+        return(NULL)
+      }
+      # Or, read in
+      read_edf_file(infile$datapath)
     })
-
-    ### Reactive variables for conditionalPanel interaction in ui.R
-    #output$data_exists <- reactive(!is.null(edf_data()))
-    #outputOptions(output, "data_exists", suspendWhenHidden = FALSE)
 
     # Prep PSD data -------------
     psd_data <- reactive({
       prep_psd_data(edf_data())
     })
-
 
 
     # Make and export PSD plot ----------
@@ -43,7 +35,7 @@ shinyServer(function(input, output) {
         plot <- make_psd_plot(psd_data(),
                               input$psd_plot_channels,
                               input$psd_frequency_range)
-        ggplot2::ggsave(file, plot, width = 6, height = 4)
+        ggplot2::ggsave(file, plot, width = 8, height = 5)
       }
     )
     output$psd_plot_ui <- renderUI({

--- a/utils.R
+++ b/utils.R
@@ -24,18 +24,25 @@ read_edf_file <- function(filepath = "data/Charliemusic_2019.04.12_08.52.45.edf"
 
   raw_data <- eegUtils::import_raw(filepath)
 
-  # Remove unused columns from `signals`
-  remove_columns <- c("INTERPOLATED", "GYROX", "GYROY", "MARKER", "MARKER_HARDWARE", "SYNC", "COUNTER")
-  raw_data$signals <- raw_data$signals %>%
-    dplyr::select(-dplyr::all_of(remove_columns),
-                  -dplyr::contains("CQ"),
-                  # eegUtils parsed this into `raw_data$timings$time`
-                  -dplyr::contains("TIME_STAMP"))
+  # Check that signal columns exist, after removing quotes from signal names
+  names(raw_data$signals) <- stringr::str_replace_all(
+    names(raw_data$signals),
+    "'|\"|`", "")
 
-  # Channels should now match `channel_options`
-  if (!identical( sort(expected_channels), sort(names(raw_data$signals)) ) ) {
-    stop("ERROR: Unexpected or missing channels in the input EDF file.")
+  if (!(all( expected_channels %in% names(raw_data$signals)) )) {
+    channel_print <- paste(expected_channels, collapse = ", ")
+    stop(
+      glue::glue(
+        "Provided EDF data does not contain the required channels.
+
+        Required channels are: {channel_print}."
+      )
+    )
   }
+
+  # Keep only expected signals
+  raw_data$signals <- raw_data$signals %>%
+    dplyr::select(dplyr::all_of(expected_channels))
 
   # Add in channel info
   raw_data$chan_info <- channel_location_df

--- a/utils.R
+++ b/utils.R
@@ -112,7 +112,7 @@ make_psd_plot <- function(plot_data, plot_channels, frequency_range = NULL) {
     )
 
   if (!is.null(frequency_range)) {
-    plot <- plot + xlim(frequency_range)
+    plot <- plot + ggplot2::xlim(frequency_range)
   }
 
   return(plot)


### PR DESCRIPTION
Closes #2 

Fixes two aspects about parsing:
- Remove any quotes that are part of the channel names, e.g. `'"AF3"` --> `"AF3"`
- Focus on keeping channels, not removing non-channels

Errors are now clearer if channels are the problem.

Also, incidentally:
- Updated download plot size for PSD line plot
- Remove default of loading example dataset
